### PR TITLE
patch-2: extension manifest v3 w/ background- and content-scripts

### DIFF
--- a/public/background.js
+++ b/public/background.js
@@ -1,0 +1,29 @@
+chrome.runtime.onInstalled.addListener(() => {
+    console.log('onInstalled');
+});
+
+/*
+ send messages in a svelte component, e.g.:
+ 
+    chrome.runtime.sendMessage(
+      {
+        payload: count,
+        topic: 'clickCounter'
+      },
+      (response) => {
+        console.log('response', response);
+      }
+    );
+*/
+chrome.runtime.onMessage.addListener(
+    (request, sender, sendResponse) => {
+        console.log(sender.tab ?
+                  "from a content script:" + sender.tab.url :
+                  "from the extension");
+        console.log('request', request);
+        
+        !!sendResponse && sendResponse({});
+
+        return true;
+    }
+  );

--- a/public/content/index.js
+++ b/public/content/index.js
@@ -1,0 +1,1 @@
+console.log("content script works");

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -2,9 +2,18 @@
     "name": "Counter App",
     "version": "1.0",
     "description": "Chrome extension + Svelte boilerplate",
+    "manifest_version": 3,
     "permissions": ["activeTab"],
-    "browser_action": {
+    "action": {
       "default_popup": "popup.html"
     },
-    "manifest_version": 2
+    "background": {
+      "service_worker": "background.js"
+    },
+    "content_scripts": [
+      {
+        "js": ["content/index.js"],
+        "matches": ["https://*/*", "http://*/*"]
+      }
+    ]
   }


### PR DESCRIPTION
patch-2:

- migrate to extension manifest v3 for more security, privacy and performance (see https://developer.chrome.com/docs/extensions/mv3/intro/)

- add background- and content-scripts